### PR TITLE
Add support for array fields

### DIFF
--- a/lib/fit4ruby/FitDefinition.rb
+++ b/lib/fit4ruby/FitDefinition.rb
@@ -77,11 +77,12 @@ module Fit4Ruby
       @@fit_entity
     end
 
-    def setup(fit_message_definition)
+    def setup(fit_message_definition, field_values_by_name = {})
       fit_message_definition.fields_by_number.each do |number, f|
+        value = field_values_by_name[f.name]
         fdf = FitDefinitionField.new
         fdf.field_definition_number = number
-        fdf.set_type(f.type)
+        fdf.set_type(f, value)
 
         data_fields << fdf
       end

--- a/lib/fit4ruby/FitDefinitionFieldBase.rb
+++ b/lib/fit4ruby/FitDefinitionFieldBase.rb
@@ -28,11 +28,13 @@ module Fit4Ruby
       entry[2]
     end
 
-    def set_type(fit_type)
-      idx = FIT_TYPE_DEFS.index { |x| x[0] == fit_type }
+    def set_type(field, value)
+      fit_type = field.opts[:array] ? 'byte' : field.type
+      idx = FIT_TYPE_DEFS.index { |x| x[0] == field.type }
       raise "Unknown type #{fit_type}" unless idx
       self.base_type_number = idx
       self.byte_count = FIT_TYPE_DEFS[idx][3]
+      self.byte_count *= value.size if value.is_a?(Array)
     end
 
     def type(fit_type = false)

--- a/lib/fit4ruby/FitMessageRecord.rb
+++ b/lib/fit4ruby/FitMessageRecord.rb
@@ -81,12 +81,7 @@ module Fit4Ruby
         end
 
         field_name, field_def = get_field_name_and_global_def(field, obj)
-
-        if value.is_a?(Array)
-          v = value.map { |vv| (field_def || field).to_machine(vv)}
-        else
-          v = (field_def || field).to_machine(value)
-        end
+        obj.set(field_name, v = (field_def || field).to_machine(value)) if obj
 
         obj.set(field_name, v) if obj
 
@@ -185,16 +180,13 @@ module Fit4Ruby
       fields = []
       (definition.data_fields.to_a +
        definition.developer_fields.to_a).each do |field|
-        next unless @gfm
-        gfmf = @gfm.fields_by_number[field.field_definition_number]
-
         field_def = [ field.type, field.name ]
 
         # Some field types need special handling.
         if field.type == 'string'
           # We need to also include the length of the String.
           field_def << { :read_length => field.total_bytes }
-        elsif gfmf.respond_to?(:opts) && gfmf.opts[:array]
+        elsif field.is_array?
           # For Arrays we have to break them into separte fields.
           field_def = [ :array, field.name,
                         { :type => field.type.intern,

--- a/lib/fit4ruby/FitMessageRecord.rb
+++ b/lib/fit4ruby/FitMessageRecord.rb
@@ -81,7 +81,14 @@ module Fit4Ruby
         end
 
         field_name, field_def = get_field_name_and_global_def(field, obj)
-        obj.set(field_name, v = (field_def || field).to_machine(value)) if obj
+
+        if value.is_a?(Array)
+          v = value.map { |vv| (field_def || field).to_machine(vv)}
+        else
+          v = (field_def || field).to_machine(value)
+        end
+
+        obj.set(field_name, v) if obj
 
         if filter && fields_dump &&
            (filter.field_names.nil? ||
@@ -178,13 +185,16 @@ module Fit4Ruby
       fields = []
       (definition.data_fields.to_a +
        definition.developer_fields.to_a).each do |field|
+        next unless @gfm
+        gfmf = @gfm.fields_by_number[field.field_definition_number]
+
         field_def = [ field.type, field.name ]
 
         # Some field types need special handling.
         if field.type == 'string'
           # We need to also include the length of the String.
           field_def << { :read_length => field.total_bytes }
-        elsif field.is_array?
+        elsif gfmf.respond_to?(:opts) && gfmf.opts[:array]
           # For Arrays we have to break them into separte fields.
           field_def = [ :array, field.name,
                         { :type => field.type.intern,

--- a/lib/fit4ruby/GlobalFitMessage.rb
+++ b/lib/fit4ruby/GlobalFitMessage.rb
@@ -264,7 +264,7 @@ module Fit4Ruby
       gfm
     end
 
-    def write(io, local_message_type, global_fit_message = self)
+    def write(io, local_message_type, field_values_by_name = {})
       header = FitRecordHeader.new
       header.normal = 0
       header.message_type = 1
@@ -273,7 +273,7 @@ module Fit4Ruby
 
       definition = FitDefinition.new
       definition.global_message_number = @number
-      definition.setup(global_fit_message)
+      definition.setup(self, field_values_by_name)
       definition.write(io)
     end
 

--- a/spec/FitFile_spec.rb
+++ b/spec/FitFile_spec.rb
@@ -72,7 +72,7 @@ describe Fit4Ruby do
       end
     end
     a.new_session({ :timestamp => ts, :sport => 'running',
-                    :time_in_hr_zone => [1] })
+                    :time_in_hr_zone => [1,2,3,4,5] })
     a.new_event({ :timestamp => ts, :event => 'recovery_time',
                   :event_type => 'marker',
                   :recovery_time => 2160 })
@@ -118,7 +118,7 @@ describe Fit4Ruby do
     b = Fit4Ruby.read(fit_file)
     expect(b.laps.count).to eq 6
     expect(b.lengths.count).to eq 0
-    expect(b.sessions.last.time_in_hr_zone).to eq [1]
+    expect(b.sessions.last.time_in_hr_zone).to eq [1,2,3,4,5]
     expect(b.inspect).to eq(activity.inspect)
   end
 

--- a/spec/FitFile_spec.rb
+++ b/spec/FitFile_spec.rb
@@ -71,7 +71,8 @@ describe Fit4Ruby do
         laps += 1
       end
     end
-    a.new_session({ :timestamp => ts, :sport => 'running' })
+    a.new_session({ :timestamp => ts, :sport => 'running',
+                    :time_in_hr_zone => [1] })
     a.new_event({ :timestamp => ts, :event => 'recovery_time',
                   :event_type => 'marker',
                   :recovery_time => 2160 })
@@ -117,6 +118,7 @@ describe Fit4Ruby do
     b = Fit4Ruby.read(fit_file)
     expect(b.laps.count).to eq 6
     expect(b.lengths.count).to eq 0
+    expect(b.sessions.last.time_in_hr_zone).to eq [1]
     expect(b.inspect).to eq(activity.inspect)
   end
 


### PR DESCRIPTION
Seems like atm Fit4Ruby does not support saving object with Array fields (see PR's FitFile_spec.rb). Reading them from a normal FIT file seems fine but it won't when it's from a FIT file generated out of Fit4Ruby objects with arrays (e.g., Session, Lap, etc...) So it also seems that the library is writing invalid files without warnings. (Eventually it might be nice to add support for field-assignment validation based on the global specification)

This is just a WIP as I'm not sure that that's correct and mostly because I'm not being able to add support for arrays with more than one object/value! If you modify the test I provided to something like: `:time_in_hr_zone => [1,2]` (instead of the `:time_in_hr_zone => [1]`) it will fail. It seems to be something related to the `:initial_length` in `FitMessageRecord#produce()` but not sure. I tried with a few different things but can't figure out how to get the right `:initial_length` (if that's indeed what's going on...). 

Is this something you might be interested in adding to the library? I think better field validation against the field/messages specification/dictionary would help a lot when debugging FIT file parsing errors.
