### PR TITLE
Allow an empty crc in a 14 byte header

### DIFF
--- a/lib/fit4ruby/FitHeader.rb
+++ b/lib/fit4ruby/FitHeader.rb
@@ -62,7 +62,7 @@ EOT
     end
 
     def has_crc?
-      header_size.snapshot == 14
+      header_size.snapshot == 14 && crc != 0x0000
     end
 
     def end_pos


### PR DESCRIPTION
As specified in ANT FIT Protocol Rev2.4 Paragraph 3.3.1 "Computing the CRC
is optional when using a 14 byte file header, it is permissible to set it to
0x0000."

The FIT files from my forrunner 610 have not crc set. The two crc bytes in the file header are 0x0000. As specified in the protocol this is allowed. However the code this not account for this. Without this fix, reading the FIT file wil log an Error