### PR TITLE
add support for converting celsius to fahrenheit

### DIFF
--- a/lib/fit4ruby/Converters.rb
+++ b/lib/fit4ruby/Converters.rb
@@ -37,6 +37,14 @@ module Fit4Ruby
       factor
     end
 
+    def convert_value(from_value, from_unit, to_unit)
+      if from_unit == 'C' and to_unit == 'F'
+        return (from_value * 9 / 5) + 32
+      end
+
+      return from_value * conversion_factor(from_unit, to_unit)
+    end
+
     def speedToPace(speed, distance = 1000.0)
       if speed && speed > 0.01
         # We only show 2 fractional digits, so make sure we round accordingly

--- a/lib/fit4ruby/FitDataRecord.rb
+++ b/lib/fit4ruby/FitDataRecord.rb
@@ -82,7 +82,7 @@ module Fit4Ruby
         end
       end
 
-      value * conversion_factor(unit, to_unit)
+      value = convert_value(value, unit, to_unit)
     end
 
     def ==(fdr)


### PR DESCRIPTION
The FIT file format stores temperatures in celsius. There's no fixed multiplier for converting celsius to fahrenheit so add a new function convert_value() that accepts the original value so that it can be properly converted.