### PR TITLE
`bindata` translator improvements (make Ruby code more idiomatic and simpler)

### DIFF
--- a/lib/fit4ruby/BDFieldNameTranslator.rb
+++ b/lib/fit4ruby/BDFieldNameTranslator.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby -w
 # encoding: UTF-8
 #
-# = FitDataRecord.rb -- Fit4Ruby - FIT file processing library for Ruby
+# = BDFieldNameTranslator.rb -- Fit4Ruby - FIT file processing library for Ruby
 #
 # Copyright (c) 2020 by Chris Schlaeger <cs@taskjuggler.org>
 #

--- a/lib/fit4ruby/BDFieldNameTranslator.rb
+++ b/lib/fit4ruby/BDFieldNameTranslator.rb
@@ -23,11 +23,7 @@ module Fit4Ruby
     }
 
     def to_bd_field_name(name)
-      if (bd_name = BD_DICT[name])
-        return bd_name
-      end
-
-      name
+      BD_DICT.fetch(name, name)
     end
 
   end

--- a/spec/BDFieldNameTranslator_spec.rb
+++ b/spec/BDFieldNameTranslator_spec.rb
@@ -1,0 +1,34 @@
+#!/usr/bin/env ruby -w
+# encoding: UTF-8
+#
+# = BDFieldNameTranslator_spec.rb -- Fit4Ruby - FIT file processing library for Ruby
+#
+# Copyright (c) 2014, 2015 by Chris Schlaeger <cs@taskjuggler.org>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of version 2 of the GNU General Public License as
+# published by the Free Software Foundation.
+#
+
+$:.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
+
+require 'fit4ruby/BDFieldNameTranslator'
+
+describe Fit4Ruby::BDFieldNameTranslator do
+
+  include described_class
+
+  it 'should translate "array" to "_array"' do
+    expect(to_bd_field_name('array')).to eq('_array')
+  end
+
+  it 'should translate "type" to "_type"' do
+    expect(to_bd_field_name('type')).to eq('_type')
+  end
+
+  it 'should NOT translate "blegga"' do
+    expect(to_bd_field_name('blegga')).to eq('blegga')
+  end
+
+end
+


### PR DESCRIPTION
Minor change to the `BDFieldNameTranslator#to_bd_field_name` method, by making the `BD_DICT` lookup slightly more idiomatic: instead of using [`Hash#[]`](https://ruby-doc.org/3.3.3/Hash.html#method-i-5B-5D) it now uses [`Hash#fetch`](https://ruby-doc.org/3.3.3/Hash.html#method-i-fetch) with the original name of the lookup key as the default value, meaning that if it doesn't appear in the `BD_DICT` hash, the lookup key will be returned unchanged.

To verify that this refactor is functionally equivalent to the original implementation, I have also included a spec for the `BDFieldNameTranslator` module, which runs "green" on both the master branch, as well as on the feature branch for this pull request.

Thanks, @scrapper! :pray: