### PR TITLE
Use RSpec's `described_class` to make the spec a tad  more idiomatic

### DIFF
--- a/spec/GeoMath_spec.rb
+++ b/spec/GeoMath_spec.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby -w
 # encoding: UTF-8
 #
-# = FitFile_spec.rb -- Fit4Ruby - FIT file processing library for Ruby
+# = GeoMath_spec.rb -- Fit4Ruby - FIT file processing library for Ruby
 #
 # Copyright (c) 2014, 2015 by Chris Schlaeger <cs@taskjuggler.org>
 #
@@ -27,7 +27,7 @@ describe Fit4Ruby::GeoMath do
       [ 48.17970883101225, 11.611351054161787, 100.225 ]
     ]
     points.each do |p|
-      expect(Fit4Ruby::GeoMath.distance(
+      expect(described_class.distance(
         p0_lat, p0_lon, p[0], p[1])).to be_within(0.001).of(p[2])
     end
   end


### PR DESCRIPTION
Use RSpec's `described_class` instead of hard-coding the name of the class-under-test, [which is considered slightly more idiomatic and preferable](https://dpericich.medium.com/why-you-should-use-described-class-when-writing-rspec-tests-in-rails-47a95b946505) ... also fix the name of the Ruby file in the copyright notice;  thanks, @scrapper! :pray: