### PR TITLE
Convert into clickable link (to GlobalFitMessages.rb source file)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ a.records.each do |r|
 end
 ```
 
-Please see lib/fit4ruby/GlobalFitMessages.rb for the data fields that
+Please see [`GlobalFitMessages.rb`](lib/fit4ruby/GlobalFitMessages.rb) for the data fields that
 are supported for the various FIT record types.
 
 ## License


### PR DESCRIPTION
Convert `lib/fit4ruby/GlobalFitMessages.rb` into a clickable link in the README file ... thanks @scrapper ! :pray: