### PR TITLE
Convert single example for multiple points into one example per point

### DIFF
--- a/spec/GeoMath_spec.rb
+++ b/spec/GeoMath_spec.rb
@@ -16,17 +16,17 @@ require 'fit4ruby/GeoMath'
 
 describe Fit4Ruby::GeoMath do
 
-  it 'should compute a distance between 2 points' do
-    p0_lat = 48.180506536737084
-    p0_lon = 11.611978523433208
-    points = [
-      # latitude, longitude, distance to p0 in meters
-      [ 48.180506536737084, 11.611978523433208, 0.0 ],
-      [ 48.18047543987632, 11.61195664666593, 3.821 ],
-      [ 48.18034409545362, 11.611852794885635, 20.339 ],
-      [ 48.17970883101225, 11.611351054161787, 100.225 ]
-    ]
-    points.each do |p|
+  p0_lat = 48.180506536737084
+  p0_lon = 11.611978523433208
+
+  [
+    # latitude, longitude, distance to p0 in meters
+    [ 48.180506536737084, 11.611978523433208, 0.0 ],
+    [ 48.18047543987632, 11.61195664666593, 3.821 ],
+    [ 48.18034409545362, 11.611852794885635, 20.339 ],
+    [ 48.17970883101225, 11.611351054161787, 100.225 ]
+  ].each_with_index do |p, index|
+    it "should compute a distance between 2 points (##{index})" do
       expect(described_class.distance(
         p0_lat, p0_lon, p[0], p[1])).to be_within(0.001).of(p[2])
     end


### PR DESCRIPTION
Minor refactor of the `GeoMatch` spec ... instead of having one example that tests multiple points, it now generates one example per point.

Running the spec on the master branch and the feature branch respectively shows the difference between the two approaches:

![success](https://github.com/user-attachments/assets/f003d65d-701f-41cf-80d4-b3d897d14b42)

But the real benefits of having multiple examples become evident when there's a failure:

![failure](https://github.com/user-attachments/assets/5f8fa184-0444-4c9a-b275-0dcc1f197e62)

It is now much easier to identify for which point exactly the check is failing, and - even more - it continues executing the remaining examples _(whereas before the execution would be halted by the first assertion failure)_.

This approach can be improved even further by giving each point on the list a "descriptive" name, instead of using the array index when generating the example name; also, with this new approach, some of the variables can be given more descriptive, intention-revealing names, but these changes can be made in separate PRs, once the approach in this PR has been reviewed and merged.

Thanks again, @scrapper! :pray: