### PR TITLE
performance improvement: avoid superfluous `attr_accessor` creation

### DIFF
--- a/lib/fit4ruby/FitDataRecord.rb
+++ b/lib/fit4ruby/FitDataRecord.rb
@@ -221,6 +221,11 @@ module Fit4Ruby
       # Create a new instance variable for 'name'. We initialize it with a
       # provided default value or nil.
       instance_variable_set("@#{name}", nil)
+
+      # Skip creating the accessor methods *again* (for this class)
+      # for fields that already had them defined previously.
+      return if self.class.method_defined?(name)
+
       # And create an accessor method for it as well.
       self.class.__send__(:attr_accessor, name)
     end


### PR DESCRIPTION
I noticed that processing a large amount of FIT files was quite slow, so did a bit of profiling.

Using `ruby-prof` revealed that a lot of time was spent in `Module#attr_accessor`, creating the attribute accessor methods for the fields of the various data record classes.

A FIT file containing 104 `Fit4Ruby::Record` instances for example, would call `Fit4Ruby::Record#attr_accessor` 104 times *for each field of that class* whereas it only needs to call it once _(per class, per field)_.

The fix is quite straightforward _(see diff)_ and makes reading/processing FIT files almost `20%` faster! :tada:

Benchmarking the processing of a directory containing `78` FIT files on the master branch and the feature branch respectively illustrates the performance improvement:

```diff
$ git rev-diff master refactor_attr_accessor_creation ruby benchmark_fit4ruby.rb
--- git checkout master && { ruby benchmark_fit4ruby.rb ; } ;
+++ git checkout refactor_attr_accessor_creation && { ruby benchmark_fit4ruby.rb ; } ;
@@ -1 +1 @@
- 78 FIT files processed in 22.03 seconds (avg: 0.28s/file).
+ 78 FIT files processed in 18.64 seconds (avg: 0.24s/file).
$ _
```