### PR TITLE
performance improvement: optimize CRC computation

### DIFF
--- a/lib/fit4ruby/CRC16.rb
+++ b/lib/fit4ruby/CRC16.rb
@@ -34,22 +34,22 @@ module Fit4Ruby
 
       io.seek(start_pos)
 
-      crc = 0
-      while io.pos < end_pos
-        if io.eof?
-          raise IOError, "Premature end of file"
-        end
+      number_of_bytes = end_pos - start_pos
 
-        byte = io.readbyte
+      data = io.read(number_of_bytes)
 
+      if data.nil? || data.bytesize != number_of_bytes
+        raise IOError, "Premature end of file"
+      end
+
+      data.bytes.reduce(0) do |crc, byte|
         0.upto(1) do |i|
           tmp = crc_table[crc & 0xF]
           crc = (crc >> 4) & 0x0FFF
           crc = crc ^ tmp ^ crc_table[(byte >> (4 * i)) & 0xF]
         end
+        crc
       end
-
-      crc
     end
 
   end


### PR DESCRIPTION
Hot on the heels of #33, this change speeds up processing a large amount of FIT files even more.

Using `ruby-prof` revealed that a lot of time was spent in `Fit4Ruby::CRC16#compute_crc`, caused by - as it turns out - inefficient file access.

Instead of reading the FIT data byte-per-byte, it is much more efficient to fetch all required data in a single read operation.

The fix is quite straightforward _(see diff)_ and makes reading/processing FIT files almost `20%` faster! 🎉

Benchmarking the processing of a directory containing `78` FIT files on the master branch and the feature branch respectively illustrates the performance improvement:

```diff
$ git rev-diff master refactor_crc_computation ruby benchmark_fit4ruby.rb
--- git checkout master && { ruby benchmark_fit4ruby.rb ; } ;
+++ git checkout refactor_crc_computation && { ruby benchmark_fit4ruby.rb ; } ;
@@ -1 +1 @@
- 78 FIT files processed in 22.25 seconds (avg: 0.29s/file).
+ 78 FIT files processed in 17.96 seconds (avg: 0.23s/file).
$ _
```