### PR TITLE
Fix some GHFM syntax errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ Tested devices: Garmin FR620, Fenix 3, Fenix 5, Fenix 5X, Fenix 6X
 Other Garmin devices that generate FIT files may work as well. Since I
 don't have any other devices, I can't add support for them.
 
-##Supported Operating Systems
+## Supported Operating Systems
 
 This library was developed and tested on Linux using Ruby 2.0 (MRI).
 Other operating systems that are Supported by Ruby 2.0 may probably
 work as well.
 
-##Usage
+## Usage
 
 You can create an Activity.
 


### PR DESCRIPTION
Fix two minor [GitHub Flavored Markdown](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github) syntax errors in the README file: the headers weren't being rendered properly due to the missing spaces.

---

<img width="366" alt="image" src="https://github.com/user-attachments/assets/2a128c0a-de03-48f1-8afd-3d67da0d7b26">
