### PR TITLE
refactor the `Converters` module

### DIFF
--- a/lib/fit4ruby/Converters.rb
+++ b/lib/fit4ruby/Converters.rb
@@ -21,6 +21,7 @@ module Fit4Ruby
       'kg' => { 'lbs' => 2.20462262 },
       'C' => { 'F' => 9.0 / 5.0 }
     }.freeze
+
     OFFSETS = {
       'C' => { 'F' => 32 }
     }.freeze
@@ -28,18 +29,10 @@ module Fit4Ruby
     def conversion_factor(from_unit, to_unit)
       return 1.0 if from_unit == to_unit
 
-      unless FACTORS.include?(from_unit)
-        Log.fatal 'No conversion factors defined for unit ' \
-                  "'#{from_unit}' to '#{to_unit}'"
-      end
-
-      factor = FACTORS[from_unit][to_unit]
-      if factor.nil?
-        Log.fatal "No conversion factor from '#{from_unit}' to '#{to_unit}' " \
-                  'defined.'
-      end
-
-      factor
+      FACTORS.fetch(from_unit).fetch(to_unit)
+    rescue KeyError
+      Log.fatal 'No conversion factor defined ' \
+        "from unit '#{from_unit}' to unit '#{to_unit}'"
     end
 
     def conversion_offset(from_unit, to_unit)

--- a/lib/fit4ruby/Converters.rb
+++ b/lib/fit4ruby/Converters.rb
@@ -43,10 +43,9 @@ module Fit4Ruby
     end
 
     def conversion_offset(from_unit, to_unit)
-      return 0.0 if from_unit == to_unit || !OFFSETS.include?(from_unit) ||
-                    !OFFSETS[from_unit].include?(to_unit)
+      return 0.0 if from_unit == to_unit
 
-      OFFSETS[from_unit][to_unit]
+      OFFSETS.fetch(from_unit, {}).fetch(to_unit, 0.0)
     end
 
     def speedToPace(speed, distance = 1000.0)

--- a/spec/Converters_spec.rb
+++ b/spec/Converters_spec.rb
@@ -1,0 +1,50 @@
+#!/usr/bin/env ruby -w
+# encoding: UTF-8
+#
+# = Converters_spec.rb -- Fit4Ruby - FIT file processing library for Ruby
+#
+# Copyright (c) 2014, 2015 by Chris Schlaeger <cs@taskjuggler.org>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of version 2 of the GNU General Public License as
+# published by the Free Software Foundation.
+#
+
+$:.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
+
+require 'fit4ruby/Converters'
+
+describe Fit4Ruby::Converters do
+
+  include described_class
+
+  describe '#conversion_offset' do
+
+    it 'should return zero for missing "from" unit' do
+      expect(conversion_offset(nil, nil)).to be_zero
+    end
+
+    it 'should return zero for missing "to" unit' do
+      expect(conversion_offset('C', nil)).to be_zero
+    end
+
+    it 'should return zero for unmapped "to" unit' do
+      expect(conversion_offset('C', 'K')).to be_zero
+    end
+
+    it 'should return zero for unmapped "from" unit' do
+      expect(conversion_offset('F', 'C')).to be_zero
+    end
+
+    it 'should return zero for matching "from"/"to" units' do
+      expect(conversion_offset('C', 'C')).to be_zero
+    end
+
+    it 'should return correct Celsius-to-Fahrenheit offset' do
+      expect(conversion_offset('C', 'F')).to eq(32)
+    end
+
+  end
+
+end
+

--- a/spec/Converters_spec.rb
+++ b/spec/Converters_spec.rb
@@ -18,6 +18,30 @@ describe Fit4Ruby::Converters do
 
   include described_class
 
+  describe '#conversion_factor' do
+
+    it 'should return one for matching "from" and "to" units' do
+      expect(conversion_factor('C', 'C')).to be(1.0)
+    end
+
+    it 'should raise an error for unsupported "from" unit' do
+      expect {
+        conversion_factor('F', 'C')
+      }.to raise_error(Fit4Ruby::Error)
+    end
+
+    it 'should raise an error for unsupported "to" unit' do
+      expect {
+        conversion_factor('C', 'K')
+      }.to raise_error(Fit4Ruby::Error)
+    end
+
+    it 'should return correct Celsius-to-Fahrenheit factor' do
+      expect(conversion_factor('C', 'F')).to eq(9.0 / 5.0)
+    end
+
+  end
+
   describe '#conversion_offset' do
 
     it 'should return zero for missing "from" unit' do


### PR DESCRIPTION
Very much in the same vein as the refactor in #29 this small PR makes the two "converter" lookups _(for `factor` and `offset` respectively)_ slightly more idiomatic and - arguably - a tad simpler: instead of using [`Hash#[]`](https://ruby-doc.org/3.3.3/Hash.html#method-i-5B-5D) it now uses [`Hash#fetch`](https://ruby-doc.org/3.3.3/Hash.html#method-i-fetch) with - where appropriate - meaningful defaults.

To verify that this refactor is functionally equivalent to the original implementation, I have also included some specs for the `Converters` module, which all run "green" on both the master branch, as well as on the feature branch for this pull request.

The new implementation also avoids superfluous hash lookups: first to test the error conditions, and then exactly the same lookups again to get the actual conversion factor or conversion offset ... this now happens in one go.

The only _(minor?)_ difference introduced by this PR is the wording of the two error messages that are logged when a lookup error occurs, which can be illustrated with:

```ruby
git rev-diff converters_refactor^^ converters_refactor rspec -I lib -r fit4ruby -fd spec/Converters_spec.rb
```

The first lookup error message changes as follows:

```diff
-No conversion factors defined for unit 'F' to 'C'
+No conversion factor defined from unit 'F' to unit 'C'
```

... and the second one as follows:

```diff
-No conversion factor from 'C' to 'K' defined.
+No conversion factor defined from unit 'C' to unit 'K'
```

... but as far as I can tell this is pretty much inconsequential :crossed_fingers:

Thanks, @scrapper! :pray: