### PR TITLE
fix two issues/bugs/typos in `Session#check()`

### DIFF
--- a/lib/fit4ruby/Session.rb
+++ b/lib/fit4ruby/Session.rb
@@ -60,10 +60,10 @@ module Fit4Ruby
         Log.fatal 'num_laps is not set'
       end
       @first_lap_index.upto(@first_lap_index - @num_laps) do |i|
-        if (lap = activity.lap[i])
+        if (lap = activity.laps[i])
           @laps << lap
         else
-          Log.fatal "Session references lap #{i} which is not contained in "
+          Log.fatal "Session references lap #{i} which is not contained in " \
                     "the FIT file."
         end
       end


### PR DESCRIPTION
This PR addresses the `NoMethodError` issue mentioned in #38:

```ruby
undefined method `lap' for an instance of Fit4Ruby::Activity
```

... by fixing a typo: `activity.lap` should be `activity.laps`

It also fixes another minor issue with the fatal error message:

```
Session references lap 0 which is not contained in 
```

... by correcting the line continuation.

Note that this PR doesn't address the "empty enumerator" issue yet, so in and of itself it doesn't really fix much, but I will issue a separate PR to fix the enumeration logic ... thanks, @scrapper !